### PR TITLE
Ignore vendor dir in sphinx-build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,7 +73,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'vendor']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
This fixes the ugly notices seen in e.g. https://travis-ci.org/savaslabs/developer-docs/builds/121529875#L762